### PR TITLE
chore(renovate): migrate to renovate-presets default.json5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5"
+  ]
+}


### PR DESCRIPTION
Replaces `config:recommended` with `github>giantswarm/renovate-presets:default.json5`.

The old `renovate.json` is replaced by `renovate.json5`.

No repo-specific configuration was present, so nothing is retained beyond the base preset.