### PR TITLE
chore: use Giant Swarm vSphere app icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update app icon to the Giant Swarm vSphere icon (`https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png`), replacing the upstream third-party logo.
+
 ## [3.4.3] - 2025-12-19
 
 ### Changed

--- a/helm/vsphere-csi-driver/Chart.yaml
+++ b/helm/vsphere-csi-driver/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - vsphere
   - vmware
   - csi
-icon: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/docs/vmware_logo.png
+icon: https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
 annotations:


### PR DESCRIPTION
Replaces the upstream third-party chart icon (`kubernetes/cloud-provider-vsphere` VMware logo) with the Giant Swarm shared vSphere web-asset, matching the other vSphere charts (`cluster-vsphere`, `cloud-provider-vsphere-app`, etc.):

`https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png`

The `vsphere/2` icon set is already live, so there is no rollout dependency.
